### PR TITLE
Create `PayPalViewModel`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
     implementation libs.androidx.core.ktx
     implementation libs.androidx.lifecycle.runtime.ktx
+    implementation libs.androidx.lifecycle.runtime.compose
     implementation libs.androidx.activity.compose
     implementation platform(libs.androidx.compose.bom)
     implementation libs.androidx.ui

--- a/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.firstapp.paypaldemo
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -53,5 +54,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // Let the coordinator handle finishing PayPal after browser return
+        coordinatorViewModel.handleOnNewIntent(intent)
     }
 }

--- a/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.firstapp.paypaldemo
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -54,11 +53,5 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        // Let the coordinator handle finishing PayPal after browser return
-        coordinatorViewModel.handleOnNewIntent(intent)
     }
 }

--- a/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/MainActivity.kt
@@ -33,10 +33,6 @@ class MainActivity : ComponentActivity() {
 
                     // Basic “router” approach or wrap in your NavHost:
                     CheckoutFlow(
-                        onPayWithPayPal = { amount ->
-                            coordinatorViewModel.initializePayPalClient(this.applicationContext)
-                            coordinatorViewModel.startPayPalCheckout(this, amount)
-                        },
                         onPayWithLink = { amount ->
                             val uri =
                                 "https://www.sandbox.paypal.com/ncp/payment/BFXRZ54VKCAQ6".toUri()

--- a/app/src/main/java/com/firstapp/paypaldemo/cardcheckout/CardCheckoutView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/cardcheckout/CardCheckoutView.kt
@@ -40,9 +40,6 @@ fun CardCheckoutView(
     val validationVM = remember { CardCheckoutValidationViewModel() }
     // Retrieve the cardPaymentViewModel from coordinator
 
-    // We also need the current Activity to pass to checkoutWithCard:
-    val activity = LocalActivityResultRegistryOwner.current as ComponentActivity
-
     // Observe states from validationVM
     var cardNumber by rememberSaveable { mutableStateOf(validationVM.cardNumber) }
     var expirationDate by rememberSaveable { mutableStateOf(validationVM.expirationDate) }

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartUiState.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartUiState.kt
@@ -3,5 +3,6 @@ package com.firstapp.paypaldemo.main
 data class CartUiState(
     val items: List<Item>,
     val totalAmount: Double,
-    val checkoutState: CheckoutState
+    val checkoutState: CheckoutState,
+    val didInitiateCheckout: Boolean
 )

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartUiState.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartUiState.kt
@@ -1,0 +1,7 @@
+package com.firstapp.paypaldemo.main
+
+data class CartUiState(
+    val items: List<Item>,
+    val totalAmount: Double,
+    val checkoutState: CheckoutState
+)

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
@@ -1,5 +1,6 @@
 package com.firstapp.paypaldemo.main
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -164,7 +166,7 @@ fun CartItemView(item: Item) {
             modifier = Modifier
                 .fillMaxWidth(),
             shape = RoundedCornerShape(8.dp),
-            border = androidx.compose.foundation.BorderStroke(1.dp, Color.Black),
+            border = BorderStroke(1.dp, Color.Black),
         ) {
             Row(
                 modifier = Modifier
@@ -245,16 +247,18 @@ fun PaymentButton(
     }
 }
 
-//@ExperimentalMaterial3Api
-//@Preview
-//@Composable
-//fun CartViewPreview() {
-//    MaterialTheme {
-//        Surface(modifier = Modifier.fillMaxSize()) {
-//            CartView(
-//                onPayWithCard = {},
-//                onPayWithPayPal = {}
-//            )
-//        }
-//    }
-//}
+@ExperimentalMaterial3Api
+@Preview
+@Composable
+fun CartViewPreview() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            CartView(
+                onPayWithCard = {},
+                onPayWithPayPal = {},
+                shoppingCartItems = shoppingCartItems,
+                onPayWithLink = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
@@ -130,17 +130,27 @@ fun CartView(
         }
 
         Spacer(modifier = Modifier.weight(1f))
-        PayPalButton(
-            cornerRadius = payPalButtonCornerRadius,
-            modifier = Modifier.fillMaxWidth(),
-            onClick = { onPayWithPayPal() }
-        )
-        Spacer(modifier = Modifier.height(10.dp))
-        PaymentButton(
-            text = "Pay with Card",
-            backgroundColor = Color.Black,
-            onClick = { onPayWithCard(totalAmount) }
-        )
+        if (isPaymentLinkEnabled) {
+            PaymentButton(
+                text = "Pay Now",
+                backgroundColor = Color.Black,
+                onClick = {
+                    onPayWithLink(totalAmount)
+                }
+            )
+        } else {
+            PayPalButton(
+                cornerRadius = payPalButtonCornerRadius,
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onPayWithPayPal() }
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            PaymentButton(
+                text = "Pay with Card",
+                backgroundColor = Color.Black,
+                onClick = { onPayWithCard(totalAmount) }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
@@ -56,6 +56,7 @@ fun CartView(
     onPayWithLink: (Double) -> Unit,
     onPayWithPayPal: () -> Unit,
 ) {
+    // TODO: make ShoppingCart data type with .items and .totalAmount property
     val totalAmount by remember { derivedStateOf { shoppingCartItems.sumOf { it.amount } } }
     val payPalButtonCornerRadius = with(LocalDensity.current) { 10.dp.toPx() }
 

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
@@ -26,7 +27,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +63,8 @@ fun CartView(
     // TODO: make ShoppingCart data type with .items and .totalAmount property
     val totalAmount by remember { derivedStateOf { shoppingCartItems.sumOf { it.amount } } }
     val payPalButtonCornerRadius = with(LocalDensity.current) { 10.dp.toPx() }
+
+    var isPaymentLinkEnabled by rememberSaveable { mutableStateOf(true) }
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CartView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -47,6 +48,8 @@ import com.paypal.android.paymentbuttons.PayPalButton
 import com.paypal.android.paymentbuttons.PayPalButtonColor
 import com.paypal.android.paymentbuttons.PayPalButtonLabel
 import com.paypal.android.paymentbuttons.PaymentButtonSize
+import com.paypal.android.utils.OnNewIntentEffect
+import com.paypal.android.utils.getActivityOrNull
 
 data class Item(
     val name: String,
@@ -70,6 +73,13 @@ fun CartView(
 
     // We also need the current Activity to pass to checkoutWithCard:
     val activity = LocalActivityResultRegistryOwner.current as ComponentActivity
+
+    // Capture LocalContext reference to obtain a ComponentActivity reference
+    // when PayPal launch is requested
+    val context = LocalContext.current
+    OnNewIntentEffect { newIntent ->
+        payPalViewModel.finishPayPalCheckout(newIntent)
+    }
 
     Column(
         modifier = Modifier
@@ -150,7 +160,9 @@ fun CartView(
                 cornerRadius = payPalButtonCornerRadius,
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {
-                    payPalViewModel.startPayPalCheckout(amount = totalAmount, activity = activity)
+                    context.getActivityOrNull()?.let { activity ->
+                        payPalViewModel.startPayPalCheckout(amount = totalAmount, activity = activity)
+                    }
                 }
             )
             Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
@@ -18,7 +18,8 @@ const val CLIENT_ID =
  */
 sealed class CheckoutState {
     object Idle : CheckoutState()
-    data class Loading(val message: String = "Loading...") : CheckoutState()
+    data class OrderCreateInProgress(val message: String = "Loading...") : CheckoutState()
+    data class StartPayPalInProgress(val message: String) : CheckoutState()
     data class OrderComplete(val orderId: String) : CheckoutState()
     data class Error(val message: String) : CheckoutState()
     data class PaymentLinkComplete(val uri: Uri): CheckoutState()

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
@@ -43,51 +43,29 @@ private const val TAG = "CheckoutCoordinatorViewModel"
  */
 class CheckoutCoordinatorViewModel : ViewModel() {
 
-    // The underlying PayPalWebCheckoutClient (depends on an Activity context).
-    // We'll set it on PayPal button press from CartView
-    private var payPalClient: PayPalWebCheckoutClient? = null
-
-    // The specialized PayPalViewModel. We'll create it once we have a payPalClient.
-    private var payPalViewModel: PayPalViewModel? = null
-
     // Live state (or “flow state”) to help the UI know what to display.
     private val _checkoutState = MutableStateFlow<CheckoutState>(CheckoutState.Idle)
     val checkoutState: StateFlow<CheckoutState> = _checkoutState
-
-    /**
-     * Initialize or update the PayPal client any time we have a fresh Activity reference.
-     * Alternatively, you can set up the client once in onCreate and pass it here.
-     */
-    fun initializePayPalClient(context: Context) {
-        payPalClient = null
-        payPalViewModel = null
-
-        val coreConfig = CoreConfig(CLIENT_ID)
-       PayPalWebCheckoutClient(context, coreConfig, "com.firstapp.paypaldemo").let { client ->
-           payPalClient = client
-           payPalViewModel = PayPalViewModel(client)
-       }
-    }
 
     /**
      * Start PayPal Checkout flow.
      * This is called from CartView’s “Pay with PayPal” button, for example.
      */
     fun startPayPalCheckout(activity: ComponentActivity,  amount: Double) {
-        val vm = payPalViewModel ?: return
-        viewModelScope.launch {
-            _checkoutState.value = CheckoutState.Loading("Starting PayPal Checkout")
-            vm.startPayPalCheckout(
-                amount = amount,
-                activity = activity,
-                onSuccess = {
-                    // We successfully launched the web flow, now just wait for onNewIntent to “finish”.
-                },
-                onFailure = { error ->
-                    _checkoutState.value = CheckoutState.Error(error)
-                }
-            )
-        }
+//        val vm = payPalViewModel ?: return
+//        viewModelScope.launch {
+//            _checkoutState.value = CheckoutState.Loading("Starting PayPal Checkout")
+//            vm.startPayPalCheckout(
+//                amount = amount,
+//                activity = activity,
+//                onSuccess = {
+//                    // We successfully launched the web flow, now just wait for onNewIntent to “finish”.
+//                },
+//                onFailure = { error ->
+//                    _checkoutState.value = CheckoutState.Error(error)
+//                }
+//            )
+//        }
     }
 
     fun openPaymentLink(activity: ComponentActivity, uri: Uri) {
@@ -146,13 +124,5 @@ class CheckoutCoordinatorViewModel : ViewModel() {
      */
     fun resetState() {
         _checkoutState.value = CheckoutState.Idle
-        payPalClient = null
-        payPalViewModel = null
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        payPalClient = null
-        payPalViewModel = null
     }
 }

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutCoordinatorViewModel.kt
@@ -1,23 +1,11 @@
 package com.firstapp.paypaldemo.main
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.util.Log
-import androidx.activity.ComponentActivity
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.firstapp.paypaldemo.paypalcheckout.PayPalViewModel
-import com.firstapp.paypaldemo.service.DemoMerchantAPI
-import com.paypal.android.cardpayments.CardClient
-import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
-const val CLIENT_ID = "AQTfw2irFfemo-eWG4H5UY-b9auKihUpXQ2Engl4G1EsHJe2mkpfUv_SN3Mba0v3CfrL6Fk_ecwv9EOo"
+const val CLIENT_ID =
+    "AQTfw2irFfemo-eWG4H5UY-b9auKihUpXQ2Engl4G1EsHJe2mkpfUv_SN3Mba0v3CfrL6Fk_ecwv9EOo"
 
 /**
  * Simple sealed class representing states we might show:
@@ -47,67 +35,6 @@ class CheckoutCoordinatorViewModel : ViewModel() {
     private val _checkoutState = MutableStateFlow<CheckoutState>(CheckoutState.Idle)
     val checkoutState: StateFlow<CheckoutState> = _checkoutState
 
-    /**
-     * Start PayPal Checkout flow.
-     * This is called from CartView’s “Pay with PayPal” button, for example.
-     */
-    fun startPayPalCheckout(activity: ComponentActivity,  amount: Double) {
-//        val vm = payPalViewModel ?: return
-//        viewModelScope.launch {
-//            _checkoutState.value = CheckoutState.Loading("Starting PayPal Checkout")
-//            vm.startPayPalCheckout(
-//                amount = amount,
-//                activity = activity,
-//                onSuccess = {
-//                    // We successfully launched the web flow, now just wait for onNewIntent to “finish”.
-//                },
-//                onFailure = { error ->
-//                    _checkoutState.value = CheckoutState.Error(error)
-//                }
-//            )
-//        }
-    }
-
-    fun openPaymentLink(activity: ComponentActivity, uri: Uri) {
-        val intent = CustomTabsIntent.Builder().build()
-        intent.launchUrl(activity, uri)
-    }
-
-    private fun isAppSwitchUri(uri: Uri) = uri.host == DemoMerchantAPI.APP_SWITCH_HOST
-
-    /**
-     * Called from MainActivity.onNewIntent
-     * to finish the PayPal flow after the Chrome Custom Tab returns.
-     */
-    fun handleOnNewIntent(intent: Intent) {
-        val deepLinkUri = intent.data
-        if (deepLinkUri != null && isAppSwitchUri(deepLinkUri)) {
-            val isSuccessfulDeepLink = deepLinkUri.path?.contains("success") ?: false
-            if (isSuccessfulDeepLink) {
-                _checkoutState.value = CheckoutState.PaymentLinkComplete(deepLinkUri)
-            } else {
-                Log.d(TAG, "❌ Not a success URL")
-            }
-        } else {
-            val vm = payPalViewModel ?: return
-            viewModelScope.launch {
-                _checkoutState.value = CheckoutState.Loading("Finishing PayPal Checkout")
-                vm.finishPayPalCheckout(
-                    intent = intent,
-                    onSuccess = { completedOrderId ->
-                        _checkoutState.value = CheckoutState.OrderComplete(completedOrderId)
-                    },
-                    onCanceled = {
-                        _checkoutState.value = CheckoutState.Error("Checkout canceled by user.")
-                    },
-                    onFailure = { error ->
-                        _checkoutState.value = CheckoutState.Error(error)
-                    }
-                )
-            }
-        }
-    }
-
     // For final success
     fun onCardCheckoutComplete(orderId: String) {
         _checkoutState.value = CheckoutState.OrderComplete(orderId)
@@ -117,7 +44,6 @@ class CheckoutCoordinatorViewModel : ViewModel() {
     fun showError(message: String) {
         _checkoutState.value = CheckoutState.Error(message)
     }
-
 
     /**
      * Reset or clear any error/completion state if user navigates away.

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -28,7 +28,6 @@ import com.firstapp.paypaldemo.paypalcheckout.PayWithPayPal
 
 // NOTE: The shopping cart in this example is static. This code snippet should draw a parallel
 // to the data layer in your own application
-// TODO: determine a better location for this variable that can be shared across different features
 val shoppingCartItems =
     listOf(Item(name = "10 Credit Points", amount = 19.99, imageResId = R.drawable.gold))
 

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -41,7 +41,6 @@ fun CheckoutFlow(
     NavHost(navController = navController, startDestination = "cart", modifier = modifier) {
         composable("cart") {
             CartView(
-                onPayWithPayPal = onPayWithPayPal,
                 onPayWithLink = onPayWithLink,
                 onPayWithCard = { amount -> navController.navigate("cardCheckout/$amount") }
             )

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -28,8 +28,9 @@ import com.firstapp.paypaldemo.paypalcheckout.PayWithPayPal
 
 // NOTE: The shopping cart in this example is static. This code snippet should draw a parallel
 // to the data layer in your own application
-private val shoppingCartItems =
-    listOf(Item(name = "White T-shirt", amount = 29.99, imageResId = R.drawable.tshirt))
+// TODO: determine a better location for this variable that can be shared across different features
+val shoppingCartItems =
+    listOf(Item(name = "10 Credit Points", amount = 19.99, imageResId = R.drawable.gold))
 
 @ExperimentalMaterial3Api
 @Composable

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -22,12 +22,18 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.firstapp.paypaldemo.R
 import com.firstapp.paypaldemo.cardcheckout.CardCheckoutView
+import com.firstapp.paypaldemo.paypalcheckout.PayWithPayPal
+
+// NOTE: The shopping cart in this example is static. This code snippet should draw a parallel
+// to the data layer in your own application
+private val shoppingCartItems =
+    listOf(Item(name = "White T-shirt", amount = 29.99, imageResId = R.drawable.tshirt))
 
 @ExperimentalMaterial3Api
 @Composable
 fun CheckoutFlow(
-    onPayWithPayPal: (Double) -> Unit,
     onPayWithLink: (Double) -> Unit,
     checkoutState: CheckoutState,
     onDismissError: () -> Unit,
@@ -35,14 +41,19 @@ fun CheckoutFlow(
     modifier: Modifier = Modifier
 ) {
     val navController = rememberNavController()
-
     val coordinator: CheckoutCoordinatorViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
 
     NavHost(navController = navController, startDestination = "cart", modifier = modifier) {
         composable("cart") {
             CartView(
                 onPayWithLink = onPayWithLink,
-                onPayWithCard = { amount -> navController.navigate("cardCheckout/$amount") }
+                shoppingCartItems = shoppingCartItems,
+                onPayWithCard = { amount -> navController.navigate("cardCheckout/$amount") },
+                onPayWithPayPal = {
+                    navController.navigate("payPalCheckout") {
+                        popUpTo("cart")
+                    }
+                },
             )
         }
 
@@ -62,6 +73,16 @@ fun CheckoutFlow(
                 amount = amountDouble,
                 onOrderCompleted = { orderId ->
                     navController.navigate("orderComplete/$orderId")
+                }
+            )
+        }
+
+        composable("payPalCheckout") {
+            PayWithPayPal(
+                onOrderComplete = { orderId ->
+                    navController.navigate("orderComplete/$orderId") {
+                        popUpTo("cart")
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -106,7 +106,7 @@ fun CheckoutFlow(
 
     // React to coordinator's state changes:
     when (checkoutState) {
-        is CheckoutState.Loading -> {
+        is CheckoutState.OrderCreateInProgress -> {
             LoadingOverlay(checkoutState.message)
         }
 

--- a/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/main/CheckoutFlow.kt
@@ -51,9 +51,7 @@ fun CheckoutFlow(
                 shoppingCartItems = shoppingCartItems,
                 onPayWithCard = { amount -> navController.navigate("cardCheckout/$amount") },
                 onPayWithPayPal = {
-                    navController.navigate("payPalCheckout") {
-                        popUpTo("cart")
-                    }
+                    navController.navigate("payPalCheckout") { popUpTo("cart") }
                 },
             )
         }

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
@@ -10,6 +10,7 @@ import com.firstapp.paypaldemo.main.CLIENT_ID
 import com.firstapp.paypaldemo.main.CartUiState
 import com.firstapp.paypaldemo.main.CheckoutState
 import com.firstapp.paypaldemo.main.Item
+import com.firstapp.paypaldemo.main.shoppingCartItems
 import com.firstapp.paypaldemo.service.Amount
 import com.firstapp.paypaldemo.service.DemoMerchantAPI
 import com.firstapp.paypaldemo.service.PurchaseUnit
@@ -73,7 +74,8 @@ class PayPalViewModel @Inject constructor(
                         // user has authorized their payment method and we are deep linked back into
                         // the application via onNewIntent
                         authState = result.authState
-                        checkoutState = CheckoutState.StartPayPalInProgress("Starting PayPal Checkout")
+                        checkoutState =
+                            CheckoutState.StartPayPalInProgress("Starting PayPal Checkout")
                     }
 
                     is PayPalPresentAuthChallengeResult.Failure ->
@@ -147,8 +149,7 @@ class PayPalViewModel @Inject constructor(
 
     companion object {
         private val defaultCartUiState by lazy {
-            val items =
-                listOf(Item(name = "White T-shirt", amount = 29.99, imageResId = R.drawable.tshirt))
+            val items = shoppingCartItems
             val totalAmount = items.sumOf { it.amount }
             CartUiState(
                 items = items,

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
@@ -53,7 +53,7 @@ class PayPalViewModel @Inject constructor(
      * The final 'finish' must still happen in handleOnNewIntent => finishPayPalCheckout.
      */
     fun startPayPalCheckout(activity: ComponentActivity) {
-        checkoutState = CheckoutState.Loading("Starting PayPal Checkout")
+        checkoutState = CheckoutState.OrderCreateInProgress("Starting PayPal Checkout")
         viewModelScope.launch {
             try {
                 val items = _uiState.value.items
@@ -73,9 +73,7 @@ class PayPalViewModel @Inject constructor(
                         // user has authorized their payment method and we are deep linked back into
                         // the application via onNewIntent
                         authState = result.authState
-
-                        // update UI to show Retry button
-                        _uiState.update { currentState -> currentState.copy(didInitiateCheckout = true) }
+                        checkoutState = CheckoutState.StartPayPalInProgress("Starting PayPal Checkout")
                     }
 
                     is PayPalPresentAuthChallengeResult.Failure ->
@@ -120,6 +118,9 @@ class PayPalViewModel @Inject constructor(
                 // the opportunity to relaunch the flow e.g. if they accidentally closed
                 // the Chrome Custom Tab and need to re-launch it
                 checkoutState = CheckoutState.Idle
+
+                // update UI to show Retry button
+                _uiState.update { currentState -> currentState.copy(didInitiateCheckout = true) }
             }
         }
     }

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
@@ -1,10 +1,15 @@
 package com.firstapp.paypaldemo.paypalcheckout
 
 import android.content.Context
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.firstapp.paypaldemo.R
 import com.firstapp.paypaldemo.main.CLIENT_ID
+import com.firstapp.paypaldemo.main.CartUiState
+import com.firstapp.paypaldemo.main.CheckoutState
+import com.firstapp.paypaldemo.main.Item
 import com.firstapp.paypaldemo.service.Amount
 import com.firstapp.paypaldemo.service.DemoMerchantAPI
 import com.firstapp.paypaldemo.service.PurchaseUnit
@@ -17,6 +22,10 @@ import com.paypal.android.paypalwebpayments.PayPalWebCheckoutRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -24,11 +33,18 @@ class PayPalViewModel @Inject constructor(
     @ApplicationContext context: Context
 ) : ViewModel() {
 
+    private val coreConfig = CoreConfig(CLIENT_ID)
+    private val payPalClient =
+        PayPalWebCheckoutClient(context, coreConfig, "com.firstapp.paypaldemo")
+
     private var authState: String? = null
 
-    val coreConfig = CoreConfig(CLIENT_ID)
-    val payPalClient =
-        PayPalWebCheckoutClient(context, coreConfig, "com.firstapp.paypaldemo")
+    private var _uiState = MutableStateFlow(defaultCartUiState)
+    val uiState: StateFlow<CartUiState> = _uiState.asStateFlow()
+
+    private var checkoutState
+        get() = _uiState.value.checkoutState
+        set(value) = _uiState.update { prevState -> prevState.copy(checkoutState = value) }
 
     /**
      * Launches the PayPal web checkout flow via Braintree browser switch library
@@ -36,95 +52,105 @@ class PayPalViewModel @Inject constructor(
      * onSuccess means the user was successfully sent to the browser.
      * The final 'finish' must still happen in handleOnNewIntent => finishPayPalCheckout.
      */
-    fun startPayPalCheckout(amount: Double, activity: ComponentActivity) {
+    fun startPayPalCheckout(activity: ComponentActivity) {
+        checkoutState = CheckoutState.Loading("Starting PayPal Checkout")
         viewModelScope.launch {
             try {
-                val order = DemoMerchantAPI.createOrder(
-                    intent = "CAPTURE",
-                    purchaseUnits = listOf(
-                        PurchaseUnit(
-                            amount = Amount(currencyCode = "USD", value = amount.toString())
-                        )
-                    )
-                )
+                val items = _uiState.value.items
+                val purchaseUnits = items.map { item ->
+                    PurchaseUnit(amount = Amount(currencyCode = "USD", item.amount.toString()))
+                }
+                val order =
+                    DemoMerchantAPI.createOrder(intent = "CAPTURE", purchaseUnits = purchaseUnits)
                 println("✅ Created order ${order.id}, status: ${order.status}")
 
-                val request = PayPalWebCheckoutRequest(
-                    orderId = order.id,
-                    fundingSource = PayPalWebCheckoutFundingSource.PAYPAL
-                )
-
+                val fundingSource = PayPalWebCheckoutFundingSource.PAYPAL
+                val request =
+                    PayPalWebCheckoutRequest(orderId = order.id, fundingSource = fundingSource)
                 when (val result = payPalClient.start(activity, request)) {
                     is PayPalPresentAuthChallengeResult.Success -> {
+                        // Preserve authentication state until we are able to call finish i.e. the
+                        // user has authorized their payment method and we are deep linked back into
+                        // the application via onNewIntent
                         authState = result.authState
-                        // TODO: update UIState
-//                    onSuccess()
                     }
 
-                    is PayPalPresentAuthChallengeResult.Failure -> {
-                        // TODO: update UIState
-//                    onFailure(result.error.toString())
-                    }
-
-                    else -> {
-                        // TODO: update UIState
-//                    onFailure("Unexpected error during checkout.")
-                    }
+                    is PayPalPresentAuthChallengeResult.Failure ->
+                        checkoutState = CheckoutState.Error(result.error.toString())
                 }
             } catch (e: Exception) {
-                // TODO: update UIState
-//            onFailure("❌ Failed to create order on merchant server: ${e.message}")
+                val errorMessage = "❌ Failed to create order on merchant server: ${e.message}"
+                checkoutState = CheckoutState.Error(errorMessage)
             }
-
         }
     } // startPayPalCheckout
 
     /**
      * Called after the user returns from the Chrome Custom Tab to finish the checkout.
      */
-    fun finishPayPalCheckout(
-        intent: android.content.Intent
-//        onSuccess: (String) -> Unit,
-//        onCanceled: () -> Unit,
-//        onFailure: (String) -> Unit
-    ) {
+    fun finishPayPalCheckout(intent: Intent) = checkIfPayPalAuthFinished(intent)?.let { result ->
+        when (result) {
+            is PayPalWebCheckoutFinishStartResult.Success -> {
+                val orderId = result.orderId
+                if (orderId == null) {
+                    checkoutState =
+                        CheckoutState.Error("received success but PayPal returned a null orderId")
+                } else {
+                    completeOrder(orderId)
+                }
+                discardAuthState()
+            }
+
+            is PayPalWebCheckoutFinishStartResult.Failure -> {
+                checkoutState = CheckoutState.Error(result.error.toString())
+                discardAuthState()
+            }
+
+            is PayPalWebCheckoutFinishStartResult.Canceled -> {
+                checkoutState = CheckoutState.Error("Checkout canceled by user.")
+                discardAuthState()
+            }
+
+            is PayPalWebCheckoutFinishStartResult.NoResult -> {
+                // Control has been passed to Chrome Custom Tab. By making the UI idle,
+                // The user's intent cannot be determined by the SDK. By returning the UI
+                // to an idle state, we can give users the opportunity to relaunch the flow
+                // e.g. if they accidentally closed the Chrome Custom Tab and need to re-launch it
+                checkoutState = CheckoutState.Idle
+            }
+        }
+    }
+
+    // Only check for PayPal Auth completion when auth state exists
+    private fun checkIfPayPalAuthFinished(intent: Intent): PayPalWebCheckoutFinishStartResult? =
+        authState?.let { payPalClient.finishStart(intent, it) }
+
+    private fun completeOrder(orderId: String) {
         viewModelScope.launch {
-            val result = authState?.let { existingAuthState ->
-                payPalClient.finishStart(intent, existingAuthState)
-            }
+            val finalOrder = DemoMerchantAPI.completeOrder(orderId, "CAPTURE")
+            println("✅ captured order: ${finalOrder.id}")
+            checkoutState = CheckoutState.OrderComplete(finalOrder.id)
+        }
+    }
 
-            when (result) {
-                is PayPalWebCheckoutFinishStartResult.Success -> {
-                    val orderId = result.orderId
-                    if (orderId == null) {
-                        // TODO: update UI
-//                    onFailure("received success but PayPal returned a null orderId")
-                    } else {
-                        val finalOrder = DemoMerchantAPI.completeOrder(orderId, "CAPTURE")
-                        println("✅ captured order: ${finalOrder.id}")
+    private fun discardAuthState() {
+        // Always discard auth state when a transaction is considered finished
+        // e.g. Success, Failure and Canceled states. You may choose to clear auth state when
+        // there is NoResult, but you will in that case need to create a new order to launch
+        // the PayPal Web flow
+        authState = null
+    }
 
-                        // TODO: update UI
-//                    onSuccess(finalOrder.id)
-                    }
-                }
-
-                is PayPalWebCheckoutFinishStartResult.Failure -> {
-                    // TODO: update UI
-//                onFailure(result.error.toString())
-                }
-
-                is PayPalWebCheckoutFinishStartResult.Canceled -> {
-                    // TODO: update UI
-//                onCanceled()
-                }
-
-                else -> {
-                    // TODO: update UI
-//                onFailure("Unexpected error occurred while completing the checkout.")
-                }
-            }
-
+    companion object {
+        private val defaultCartUiState by lazy {
+            val items =
+                listOf(Item(name = "White T-shirt", amount = 29.99, imageResId = R.drawable.tshirt))
+            val totalAmount = items.sumOf { it.amount }
+            CartUiState(
+                items = items,
+                totalAmount = totalAmount,
+                checkoutState = CheckoutState.Idle
+            )
         }
     }
 }
-

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayPalViewModel.kt
@@ -73,6 +73,9 @@ class PayPalViewModel @Inject constructor(
                         // user has authorized their payment method and we are deep linked back into
                         // the application via onNewIntent
                         authState = result.authState
+
+                        // update UI to show Retry button
+                        _uiState.update { currentState -> currentState.copy(didInitiateCheckout = true) }
                     }
 
                     is PayPalPresentAuthChallengeResult.Failure ->
@@ -112,10 +115,10 @@ class PayPalViewModel @Inject constructor(
             }
 
             is PayPalWebCheckoutFinishStartResult.NoResult -> {
-                // Control has been passed to Chrome Custom Tab. By making the UI idle,
-                // The user's intent cannot be determined by the SDK. By returning the UI
-                // to an idle state, we can give users the opportunity to relaunch the flow
-                // e.g. if they accidentally closed the Chrome Custom Tab and need to re-launch it
+                // Control has been passed to Chrome Custom Tab. The user's intent cannot be
+                // determined by the SDK. By returning the UI to an idle state, we can give users
+                // the opportunity to relaunch the flow e.g. if they accidentally closed
+                // the Chrome Custom Tab and need to re-launch it
                 checkoutState = CheckoutState.Idle
             }
         }
@@ -149,7 +152,8 @@ class PayPalViewModel @Inject constructor(
             CartUiState(
                 items = items,
                 totalAmount = totalAmount,
-                checkoutState = CheckoutState.Idle
+                checkoutState = CheckoutState.Idle,
+                didInitiateCheckout = false
             )
         }
     }

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayWithPayPal.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayWithPayPal.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,7 +14,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,15 +53,49 @@ fun PayWithPayPal(
             onOrderComplete(result.orderId)
         }
     }
+    PayWithPayPal(
+        didInitiateCheckout = uiState.didInitiateCheckout,
+        onRetryStartPayPal = {
+            context.getActivityOrNull()?.let { activity ->
+                viewModel.startPayPalCheckout(activity = activity)
+            }
+        }
+    )
+}
 
+@Composable
+fun PayWithPayPal(didInitiateCheckout: Boolean, onRetryStartPayPal: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .padding(20.dp),
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.Start
+        verticalArrangement =
+            Arrangement.spacedBy(10.dp, alignment = Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        CircularProgressIndicator()
         Text("Redirecting to PayPal...")
+
+        val buttonAlpha = if (didInitiateCheckout) 1.0f else 0.0f
+        Button(
+            onClick = onRetryStartPayPal,
+            modifier = Modifier
+                .alpha(buttonAlpha)
+        ) {
+            Text("Retry")
+        }
     }
+}
+
+@Preview
+@Composable
+fun PayWithPayPalPreviewInitial() {
+    PayWithPayPal(didInitiateCheckout = false, onRetryStartPayPal = {})
+}
+
+@Preview
+@Composable
+fun PayWithPayPalPreviewAllowRetry() {
+    PayWithPayPal(didInitiateCheckout = true, onRetryStartPayPal = {})
 }

--- a/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayWithPayPal.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/paypalcheckout/PayWithPayPal.kt
@@ -1,0 +1,63 @@
+package com.firstapp.paypaldemo.paypalcheckout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.firstapp.paypaldemo.main.CheckoutState
+import com.paypal.android.utils.OnNewIntentEffect
+import com.paypal.android.utils.getActivityOrNull
+
+@Composable
+fun PayWithPayPal(
+    onOrderComplete: (orderId: String) -> Unit,
+    viewModel: PayPalViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Capture LocalContext reference to obtain a ComponentActivity reference
+    // when PayPal launch is requested
+    val context = LocalContext.current
+
+    // When PayWithPayPal is presented, immediately launch PayPal flow
+    LaunchedEffect(Unit) {
+        context.getActivityOrNull()?.let { activity ->
+            viewModel.startPayPalCheckout(activity = activity)
+        }
+    }
+
+    // Handle finishing PayPal return from Chrome Custom Tab
+    OnNewIntentEffect { newIntent ->
+        viewModel.finishPayPalCheckout(newIntent)
+    }
+
+    // Notify Order Complete
+    LaunchedEffect(uiState.checkoutState) {
+        (uiState.checkoutState as? CheckoutState.OrderComplete)?.let { result ->
+            onOrderComplete(result.orderId)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.Start
+    ) {
+        Text("Redirecting to PayPal...")
+    }
+}

--- a/app/src/main/java/com/firstapp/paypaldemo/utils/ContextExt.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/utils/ContextExt.kt
@@ -1,0 +1,12 @@
+package com.paypal.android.utils
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+
+// Ref: https://stackoverflow.com/a/68423182
+fun Context.getActivityOrNull(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.getActivityOrNull()
+    else -> null
+}

--- a/app/src/main/java/com/firstapp/paypaldemo/utils/OnLifecycleOwnerResumeEffect.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/utils/OnLifecycleOwnerResumeEffect.kt
@@ -1,0 +1,20 @@
+package com.paypal.android.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+
+@Composable
+fun OnLifecycleOwnerResumeEffect(callback: () -> Unit) {
+    // Ref: https://stackoverflow.com/a/66549433
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
+    LaunchedEffect(lifecycleState) {
+        if (lifecycleState == Lifecycle.State.RESUMED) {
+            callback()
+        }
+    }
+}

--- a/app/src/main/java/com/firstapp/paypaldemo/utils/OnNewIntentEffect.kt
+++ b/app/src/main/java/com/firstapp/paypaldemo/utils/OnNewIntentEffect.kt
@@ -1,0 +1,22 @@
+package com.paypal.android.utils
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.util.Consumer
+
+@Composable
+fun OnNewIntentEffect(callback: (newIntent: Intent) -> Unit) {
+    val context = LocalContext.current
+    // pass "Unit" to register listener only once
+    DisposableEffect(Unit) {
+        val listener = Consumer<Intent> { newIntent ->
+            callback(newIntent)
+        }
+        context.getActivityOrNull()?.addOnNewIntentListener(listener)
+        onDispose {
+            context.getActivityOrNull()?.removeOnNewIntentListener(listener)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
+lifecycleRuntime = "2.8.7"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
 navigationCompose = "2.7.5"
@@ -20,7 +20,8 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntime" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## What

- This PR adds `PayPalViewModel` to the project as a standalone view model for the Demo of Pay with PayPal 
- By removing `PayPalWebCheckoutClient` ownership from the `CheckoutCoordinatorViewModel`, it's state no longer needs to be reset

## Why

- This PR is the second in a series of PRs to align with Android best practices seen in the [android/nowinandroid](https://github.com/android/nowinandroid) sample app 
- Previous PR: https://github.com/paypal-examples/paypal-android-sdk-demo-app/pull/8